### PR TITLE
fix bug calculate_crc

### DIFF
--- a/fittie/fitfile/header.py
+++ b/fittie/fitfile/header.py
@@ -84,7 +84,7 @@ def decode_header(data: Streamable) -> Header:
             (crc,) = struct.unpack("H", data.read(2))
             calculated_crc = calculate_crc(header_data)
 
-            if crc != calculated_crc:
+            if crc != calculated_crc and data.should_calculate_crc:
                 raise DecodeException(
                     detail="invalid crc checksum in file header", position=0
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import BinaryIO
 
 import pytest
-
 from fittie.fitfile.data_message import DataMessage
 from fittie.fitfile.definition_message import DefinitionMessage
 from fittie.fitfile.field_definitions import FieldDefinition


### PR DESCRIPTION
The parameter calculate_crc was only applied on the decode function and not on the header function. 

Thanks for the nice package! 